### PR TITLE
pad hex value with leading zeroes

### DIFF
--- a/hsla.html
+++ b/hsla.html
@@ -101,7 +101,13 @@ p, h1 {font-family:arial, helvetica, sans-serif;}
 				var blue = parseInt(digits[4]);
 				
 				var rgb = blue | (green << 8) | (red << 16);
-				return digits[1] + '#' + rgb.toString(16);
+								
+				var hex = rgb.toString(16);
+				while (hex.length < 6) {
+				    hex = "0" + hex;
+				}
+				
+				return digits[1] + '#' + hex;
 			};
 
               changeHSL();


### PR DESCRIPTION
Responding to your off-hand comment from the Frontend Masters Workshop, here is a pull request that pads the hex value of the color with leading zeroes so that black isn't represented as #0 any longer. (great workshop btw!)
