### PR TITLE
Front-padding the HEX string

### DIFF
--- a/hsla.html
+++ b/hsla.html
@@ -101,7 +101,7 @@ p, h1 {font-family:arial, helvetica, sans-serif;}
 				var blue = parseInt(digits[4]);
 				
 				var rgb = blue | (green << 8) | (red << 16);
-				return digits[1] + '#' + rgb.toString(16);
+				return digits[1] + '#' + ('00000' + rgb.toString(16)).slice(-6);
 			};
 
               changeHSL();


### PR DESCRIPTION
For low-luminance HEX string contains leading zeros for the color
components, which are discarded by toString.
